### PR TITLE
Fix domain for main doc links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build: build/index.html
 
 build/cpsc411.sxref:
 	mkdir -p build
-	scribble --dest ./build --dest-name cpsc411 --htmls --info-out build/cpsc411.sxref +m --redirect-main "https://docs.racket-lang.com" ++style assignment/custom.css `racket -e "(void (write-string (path->string (collection-file-path \"cpsc411.scrbl\" \"cpsc411\"))))"`
+	scribble --dest ./build --dest-name cpsc411 --htmls --info-out build/cpsc411.sxref +m --redirect-main "https://docs.racket-lang.org" ++style assignment/custom.css `racket -e "(void (write-string (path->string (collection-file-path \"cpsc411.scrbl\" \"cpsc411\"))))"`
 
 build/index.html: build/cpsc411.sxref .racodeps assignment/* appendix/*.scrbl chapter/*.scrbl *.scrbl Makefile config.rkt
 	scribble --dest-name build --htmls ++info-in build/cpsc411.sxref --redirect-main https://docs.racket-lang.org/ +m ++style assignment/custom.css index.scrbl


### PR DESCRIPTION
This fixes links from some of the book packages to main Racket topics by using the correct domain.

As an example, this [Compiler Support](https://www.students.cs.ubc.ca/~cs-411/2022w2/cpsc411/Compiler_Support.html#%28def._%28%28lib._cpsc411%2Fcompiler-lib..rkt%29._aloc~3f%29%29) section (should) now correctly link to Racket's docs for things like `boolean?`.

The book depends on the private solution repo, so I wasn't able to build the book locally to confirm this fix, but I suspect it does the right thing. 😇 